### PR TITLE
FIX | Fractal numbers

### DIFF
--- a/Common.snippet
+++ b/Common.snippet
@@ -24,7 +24,7 @@
       "template" : "[UIFont fontWithName:<NAME> size:<SIZE>]",
       "bindings" : {
         "<NAME>" : "var f = function(dict){return '@\"' + dict[\"fontName\"] + '\"';}; f(<DICT>)",
-        "<SIZE>" : "var f = function(dict){return dict[\"pointSize\"];}; f(<DICT>)"
+        "<SIZE>" : "var f = function(dict){return Math.ceil(dict[\"pointSize\"]);}; f(<DICT>)"
       }
     }
   },
@@ -32,10 +32,10 @@
     "create" : {
       "template" : "[UIColor colorWithRed:<r> green:<g> blue:<b> alpha:<a>]",
       "bindings" : {
-        "<r>" : "var f = function(dict){return dict[\"red\"];}; f(<DICT>)",
-        "<g>" : "var f = function(dict){return dict[\"green\"];}; f(<DICT>)",
-        "<b>" : "var f = function(dict){return dict[\"blue\"];}; f(<DICT>)",
-        "<a>" : "var f = function(dict){return dict[\"alpha\"];}; f(<DICT>)"
+        "<r>" : "var f = function(dict){return Number(dict[\"red\"].toFixed(4))}; f(<DICT>)",
+        "<g>" : "var f = function(dict){return Number(dict[\"green\"].toFixed(4));}; f(<DICT>)",
+        "<b>" : "var f = function(dict){return Number(dict[\"blue\"].toFixed(4));}; f(<DICT>)",
+        "<a>" : "var f = function(dict){return Number(dict[\"alpha\"].toFixed(4));}; f(<DICT>)"
       }
     }
   },

--- a/Generated/PriceView.m
+++ b/Generated/PriceView.m
@@ -10,19 +10,19 @@
 
 
 	_priceBarImageView = [UIView new];
-	_priceBarImageView.backgroundColor = [UIColor colorWithRed:0 green:0.5176470588235293 blue:1 alpha:1];
+	_priceBarImageView.backgroundColor = [UIColor colorWithRed:0 green:0.5176 blue:1 alpha:1];
 
 
 	_priceLabel = [UILabel new];
 	_priceLabel.text = @"$220";
-	_priceLabel.font = [UIFont fontWithName:@"SourceSansPro-Regular" size:13.65333333333333];
-	_priceLabel.textColor = [UIColor colorWithRed:0.2039215686 green:0.2117647059 blue:0.2392156863 alpha:1];
+	_priceLabel.font = [UIFont fontWithName:@"SourceSansPro-Regular" size:14];
+	_priceLabel.textColor = [UIColor colorWithRed:0.2039 green:0.2118 blue:0.2392 alpha:1];
 
 
 	_titleLabel = [UILabel new];
 	_titleLabel.text = @"Section";
-	_titleLabel.font = [UIFont fontWithName:@"SourceSansPro-Regular" size:13.65333333333333];
-	_titleLabel.textColor = [UIColor colorWithRed:0.2039215686 green:0.2117647059 blue:0.2392156863 alpha:1];
+	_titleLabel.font = [UIFont fontWithName:@"SourceSansPro-Regular" size:14];
+	_titleLabel.textColor = [UIColor colorWithRed:0.2039 green:0.2118 blue:0.2392 alpha:1];
 
 
 	_arrow = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"arrow"]];

--- a/Generated/Sketch2CodeTest/Sketch2CodeTest.xcodeproj/project.pbxproj
+++ b/Generated/Sketch2CodeTest/Sketch2CodeTest.xcodeproj/project.pbxproj
@@ -31,7 +31,6 @@
 		F531D20E1CBC2404006C5D83 /* PriceView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PriceView.h; path = ../../PriceView.h; sourceTree = "<group>"; };
 		F531D20F1CBC2404006C5D83 /* PriceView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PriceView.m; path = ../../PriceView.m; sourceTree = "<group>"; };
 		F571705B1CC7F10E001F744E /* SourceSansPro-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SourceSansPro-Regular.ttf"; sourceTree = "<group>"; };
-		F571705D1CC82A6C001F744E /* arrow@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "arrow@2x.png"; path = "../../arrow@2x.png"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,7 +63,6 @@
 		F531D1F31CBC2022006C5D83 /* Sketch2CodeTest */ = {
 			isa = PBXGroup;
 			children = (
-				F571705D1CC82A6C001F744E /* arrow@2x.png */,
 				F531D20E1CBC2404006C5D83 /* PriceView.h */,
 				F531D20F1CBC2404006C5D83 /* PriceView.m */,
 				F531D1F71CBC2022006C5D83 /* AppDelegate.h */,


### PR DESCRIPTION
Modified binding code for UIFont's size and UIColor's red,green,blue and alpha in `Common.snippet`
- Font size is rounded without decimal digits
- UIColor properties are rounded to four decimal digits without trailing zeros (not to loose too much colour information)

Note: Sketch uses some rounding internally too, now the "Section" label is truncated
Note2: Also removed unused arrow@2x.png fileReference from the test project
